### PR TITLE
Fix setup for layer sheet

### DIFF
--- a/LayerThief.roboFontExt/lib/LTAddLayerSheet.py
+++ b/LayerThief.roboFontExt/lib/LTAddLayerSheet.py
@@ -59,15 +59,17 @@ class LTAddLayerSheet(object):
 		self.addLayerSheet.open()
 
 	def _suggestLayerName(self):
+		# suggestion is based on source font + layer, but killed on repeat
 		p = self.parent
-		n = self.parent.sourceLayerDisplayNames
 
 		suggestion = p.openFontDisplayNames[p.selectedSourceFont]
 		suggestion += " "
-		suggestion += n[p.selectedSourceLayer]
+		suggestion += self.parent.sourceLayerDisplayNames[p.selectedSourceLayer]
+
+		print(suggestion)
 
 		# already exists, no suggestion
-		if suggestion in n: 
+		if suggestion in self.parent.targetLayerDisplayNames: 
 			suggestion = ""
 
 		return suggestion
@@ -107,7 +109,8 @@ class LTAddLayerSheet(object):
 		error = self.addLayerSheet.errorLabel
 		button = self.addLayerSheet.addLayerButton
 
-		if nameClean in self.parent.sourceLayerDisplayNames:
+		# don't duplicate sibling layer names
+		if nameClean in self.parent.targetLayerDisplayNames:
 			showError = 1
 			enableButton = 0
 		elif nameClean == "":

--- a/LayerThief.roboFontExt/lib/LTAddLayerSheet.py
+++ b/LayerThief.roboFontExt/lib/LTAddLayerSheet.py
@@ -66,8 +66,6 @@ class LTAddLayerSheet(object):
 		suggestion += " "
 		suggestion += self.parent.sourceLayerDisplayNames[p.selectedSourceLayer]
 
-		print(suggestion)
-
 		# already exists, no suggestion
 		if suggestion in self.parent.targetLayerDisplayNames: 
 			suggestion = ""

--- a/LayerThief.roboFontExt/lib/LayerThief.py
+++ b/LayerThief.roboFontExt/lib/LayerThief.py
@@ -27,6 +27,7 @@ class LayerThief(object):
 	openFonts = []
 	openFontDisplayNames = []
 	sourceLayerDisplayNames = []
+	targetLayerDisplayNames = []
 	targetLayerColorHues = []
 	newLayerWasAdded = 0
 	selectedSourceFont = 0
@@ -168,6 +169,12 @@ class LayerThief(object):
 
 			self.openFontDisplayNames.append(name)
 
+	def _updateLayerDisplayNames(self, popUp, layerOrder):
+		if popUp == "source":
+			self.sourceLayerDisplayNames = layerOrder
+		elif popUp == "target":
+			self.targetLayerDisplayNames = layerOrder
+
 	def _updateFontPopUp(self, popUp, preserveCurrentIndex=0):
 		p = self._getPopUpUi(popUp, "font")
 		f = self._getSelectedPopUpFont(popUp)
@@ -206,9 +213,7 @@ class LayerThief(object):
 			p.enable(0)
 		else:
 			layers = self.openFonts[f].layers
-			# source layer display names used for new layer name suggestions in LTAddLayerSheet
-			if popUpIsSource:
-				self.sourceLayerDisplayNames = self.openFonts[f].layerOrder
+			self._updateLayerDisplayNames(popUp, self.openFonts[f].layerOrder)
 			# if LTAddLayerSheet added a layer, set it as current
 			if self.newLayerWasAdded and popUpIsTarget:
 				current = len(layers) - 1
@@ -241,7 +246,7 @@ class LayerThief(object):
 				p.getNSPopUpButton().addItemWithTitle_(self.layerPopUpActionTitle)
 				self.targetLayerAddIndex = p.getNSPopUpButton().menu().numberOfItems() - 1
 			elif popUpIsSource:
-				self.sourceLayer = p.get()
+				self.selectedSourceLayer = p.get()
 
 			p.enable(1)
 
@@ -374,7 +379,7 @@ class LayerThief(object):
 	def layerPopUpCallback(self, sender):
 		s = sender.get()
 		if sender == self.w.sourceLayerPopUp:
-			self.sourceLayer = s
+			self.selectedSourceLayer = s
 			self._verifyCanCopy()
 		elif sender == self.w.targetLayerPopUp:
 			self._verifyCanCopy()


### PR DESCRIPTION
- Added a variable to track the target layer display names as well as source (self.targetLayerDisplayNames)
- Fixed a previously missed correction where self.sourceLayer should have been self.selectedSourceLayer
- Added a helper function to set layer display name variables based on the current popup
- Corrected name suggestion to draw from source layer names but limit by target layer names
- Corrected error handling to catch duplicate target layer names (was source previously)